### PR TITLE
Fixed empty body warnings by putting braces around it.

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -2078,7 +2078,7 @@ int rtw_get_bcn_keys(ADAPTER *Adapter, u8 *pframe, u32 packet_len,
 
 	       _rtw_memcpy(recv_beacon->ssid, elems.ssid, elems.ssid_len);
 	       recv_beacon->ssid_len = elems.ssid_len;
-	} else; // means hidden ssid
+	} else { ; } // means hidden ssid
 
 	/* checking RSN first */
 	if (elems.rsn_ie && elems.rsn_ie_len) {

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -1055,8 +1055,9 @@ static s32 update_attrib(_adapter *padapter, _pkt *pkt, struct pkt_attrib *pattr
 		_rtw_memcpy(pattrib->ta, get_bssid(pmlmepriv), ETH_ALEN);
 		DBG_COUNTER(padapter->tx_logs.core_tx_upd_attrib_ap);
 	} 
-	else
+	else {
 		DBG_COUNTER(padapter->tx_logs.core_tx_upd_attrib_unknown);
+	}
 
 	pattrib->pktlen = pktfile.pkt_len;
 

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -229,7 +229,7 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 		if (sel == RTW_DBGDUMP)\
 			_DBG_871X_LEVEL(_drv_always_, fmt, ##arg); \
 		else {\
-			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/; \
+			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/ { ; } \
 		} \
 	}while(0)
 
@@ -239,7 +239,7 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 		if (sel == RTW_DBGDUMP)\
 			DBG_871X_LEVEL(_drv_always_, fmt, ##arg); \
 		else {\
-			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/; \
+			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/ { ; } \
 		} \
 	}while(0)
 

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -403,10 +403,11 @@ void rtw_os_recv_indicate_pkt(_adapter *padapter, _pkt *pkt, struct rx_pkt_attri
 #endif //CONFIG_TCP_CSUM_OFFLOAD_RX
 
 		ret = rtw_netif_rx(padapter->pnetdev, pkt);
-		if (ret == NET_RX_SUCCESS)
+		if (ret == NET_RX_SUCCESS) {
 			DBG_COUNTER(padapter->rx_logs.os_netif_ok);
-		else
+		} else {
 			DBG_COUNTER(padapter->rx_logs.os_netif_err);
+		}
 	}
 }
 


### PR DESCRIPTION
Temporary enabled 'EXTRA_CFLAGS += -Wempty-body' in the Makefile and
fixed the warnings that popped up.