### PR TITLE
Kernel 4.3 and TP-Link T4U support

### DIFF
--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -229,7 +229,7 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 		if (sel == RTW_DBGDUMP)\
 			_DBG_871X_LEVEL(_drv_always_, fmt, ##arg); \
 		else {\
-			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/ { ; } \
+			_seqdump(sel, fmt, ##arg); \
 		} \
 	}while(0)
 
@@ -239,7 +239,7 @@ extern void rtl871x_cedbg(const char *fmt, ...);
 		if (sel == RTW_DBGDUMP)\
 			DBG_871X_LEVEL(_drv_always_, fmt, ##arg); \
 		else {\
-			if(_seqdump(sel, fmt, ##arg)) /*rtw_warn_on(1)*/ { ; } \
+			_seqdump(sel, fmt, ##arg); \
 		} \
 	}while(0)
 

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -298,7 +298,8 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2001, 0x3315),.driver_info = RTL8812}, /* D-Link - Cameo */
 	{USB_DEVICE(0x2001, 0x3316),.driver_info = RTL8812}, /* D-Link - Cameo */
 	{USB_DEVICE(0x13b1, 0x003f),.driver_info = RTL8812}, /* Linksys - WUSB6300 */
-	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - Archer T4U */
+	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - T4U */
+	{USB_DEVICE(0x2357, 0x0103),.driver_info = RTL8812}, /* TP-Link - T4UH */
 #endif
 
 #ifdef CONFIG_RTL8821A


### PR DESCRIPTION
* Uses '_seqdump' with >=4.3 semantics
* Updates USB device IDs for TP-Link T4U/T4UH