### PR TITLE
Disable Werror=incompatible-pointer-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXTRA_CFLAGS += -Wall
 #EXTRA_CFLAGS += -Werror
 #EXTRA_CFLAGS += -pedantic
 #EXTRA_CFLAGS += -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
-EXTRA_CFLAGS += -Werror=incompatible-pointer-types
+#EXTRA_CFLAGS += -Werror=incompatible-pointer-types # Fix compile error on gcc 4.9.4 and later
 
 EXTRA_CFLAGS += -Wno-unused-variable
 EXTRA_CFLAGS += -Wno-unused-value


### PR DESCRIPTION
This fixes the compile error I was having on gcc 4.9.4 and later