### PR TITLE
Fix build with kernel 4.11.9

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3949,7 +3949,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,11,9))
+	mon_ndev->needs_free_netdev = false;
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+#else
 	mon_ndev->destructor = rtw_ndev_destructor;
+#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;


### PR DESCRIPTION
Second attempt after screwing up #45.

This patch is needed to compile with kernel 4.11.9 after https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/commit/include/linux/netdevice.h?id=cf124db566e6b036b8bcbe8decbed740bdfac8c6

This kernel change was originally introduced in 4.12-rc6 but has been backported to 4.11.9

Build tested only, as I don't have any rtl8821au hardware.