### PR TITLE
add fixes for kernel >= 4.12.0 on Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Module.symvers
 modules.order
 .tmp_versions/
+*.sublime-*

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -39,6 +39,10 @@
 
 #ifdef PLATFORM_LINUX
 #include <osdep_service_linux.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/signal.h>
+#endif
 #endif
 
 #ifdef PLATFORM_OS_XP

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -800,6 +800,19 @@ check_bss:
 		#endif
 
 		DBG_871X(FUNC_ADPT_FMT" call cfg80211_roamed\n", FUNC_ADPT_ARG(padapter));
+		#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+		{
+			struct cfg80211_roam_info roam_info = {
+				.channel = notify_channel,
+				.bssid = cur_network->network.MacAddress,
+				.req_ie = pmlmepriv->assoc_req+sizeof(struct rtw_ieee80211_hdr_3addr)+2,
+				.req_ie_len = pmlmepriv->assoc_req_len-sizeof(struct rtw_ieee80211_hdr_3addr)-2,
+				.resp_ie = pmlmepriv->assoc_rsp+sizeof(struct rtw_ieee80211_hdr_3addr)+6,
+				.resp_ie_len = pmlmepriv->assoc_rsp_len-sizeof(struct rtw_ieee80211_hdr_3addr)-6,
+			};
+			cfg80211_roamed(padapter->pnetdev, &roam_info, GFP_ATOMIC);
+		}
+		#else
 		cfg80211_roamed(padapter->pnetdev
 			#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39) || defined(COMPAT_KERNEL_RELEASE)
 			, notify_channel
@@ -810,6 +823,7 @@ check_bss:
 			, pmlmepriv->assoc_rsp+sizeof(struct rtw_ieee80211_hdr_3addr)+6
 			, pmlmepriv->assoc_rsp_len-sizeof(struct rtw_ieee80211_hdr_3addr)-6
 			, GFP_ATOMIC);
+		#endif
 	}
 	else
 	{
@@ -1876,7 +1890,11 @@ enum nl80211_iftype {
 */
 static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 				     struct net_device *ndev,
-				     enum nl80211_iftype type, u32 *flags,
+				     #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0))
+						enum nl80211_iftype type,
+					#else
+						enum nl80211_iftype type, u32 *flags,
+					#endif
 				     struct vif_params *params)
 {
 	enum nl80211_iftype old_type;
@@ -3949,7 +3967,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,9))
+	mon_ndev->needs_free_netdev = false;
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+	#else
 	mon_ndev->destructor = rtw_ndev_destructor;
+	#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;
@@ -4016,7 +4039,12 @@ static int
 	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		unsigned char name_assign_type,
 	#endif
-		enum nl80211_iftype type, u32 *flags, struct vif_params *params)
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0))
+		enum nl80211_iftype type,
+	#else
+		enum nl80211_iftype type, u32 *flags,
+	#endif
+		struct vif_params *params)
 {
 	int ret = 0;
 	struct net_device* ndev = NULL;
@@ -4453,7 +4481,8 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *n
 
 struct sta_info *rtw_sta_info_get_by_idx(const int idx, struct sta_priv *pstapriv)
 
-{
+{
+
 	_list	*phead, *plist;
 	struct sta_info *psta = NULL;
 	int i = 0;
@@ -6412,7 +6441,11 @@ static void rtw_cfg80211_preinit_wiphy(_adapter *adapter, struct wiphy *wiphy)
 #endif
 
 #if defined(CONFIG_PM) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0))
-	wiphy->flags |= WIPHY_FLAG_SUPPORTS_SCHED_SCAN;
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0))
+	wiphy->max_sched_scan_reqs = 1;
+	#else
+ 	wiphy->flags |= WIPHY_FLAG_SUPPORTS_SCHED_SCAN;
+	#endif
 #ifdef CONFIG_PNO_SUPPORT
 	wiphy->max_sched_scan_ssids = MAX_PNO_LIST_COUNT;
 #endif


### PR DESCRIPTION
I used your repository as a base for compiling this driver on Fedora 27 for a NetGear, Inc. A6100 AC600 DB Wireless Adapter.

The problems I encountered were mostly the result of some changed function definitions and I used kernel version checks wherever I made changes so it shouldn't break anything.

My fixes were drawn from a few different places, including:
http://lkml.iu.edu/hypermail/linux/kernel/1704.2/00921.html
https://github.com/Mange/rtl8192eu-linux-driver/commit/555b3104662883c5c8f7378c5e94dd7f30f2892b
https://github.com/diederikdehaas/rtl8812AU/commit/92a3b52467d3f1e3a4e8894269405e8c142cdff9

  